### PR TITLE
Improve file upload error UX

### DIFF
--- a/app.py
+++ b/app.py
@@ -105,8 +105,8 @@ app = Flask(__name__, template_folder='html')
 # This tells Flask to store session data on disk in a temporary directory, which allows much larger payloads
 app.config['SESSION_TYPE'] = 'filesystem'  # Store sessions in the local file system
 app.config['SESSION_PERMANENT'] = False
-# Enforce a size limit of 15mb to the app
-app.config['MAX_CONTENT_LENGTH'] = 15 * 1024 * 1024  # 15 MB
+# Enforce a size limit of 30mb to the app
+app.config['MAX_CONTENT_LENGTH'] = 30 * 1024 * 1024  # 30 MB
 Session(app)
 #
 app.secret_key = os.getenv('SECRET_KEY')
@@ -551,9 +551,9 @@ def download_file():
 @app.errorhandler(RequestEntityTooLarge)
 def handle_large_file(error):
     """
-    Custom handler for files >15MB
+    Custom handler for files >30MB
     """
-    return render_template("upload.html", error="File too large. Please upload a file under 15MB."), 413
+    return render_template("upload.html", error="File too large. Please upload a file under 30MB."), 413
 
 
 if __name__ == '__main__':

--- a/html/upload.html
+++ b/html/upload.html
@@ -25,6 +25,9 @@
         <div class="upload-error">
         {{ error }}
         </div>
+        <script>
+            alert("{{ error }}");
+        </script>
         {% endif %}
 
         <!-- Sheet Selection -->


### PR DESCRIPTION
## Summary
- raise file upload limit to 30MB
- show an alert if the uploaded file is too large

## Testing
- `python -m py_compile app.py country_mapping.py`

------
https://chatgpt.com/codex/tasks/task_e_687ffc67f5c48327ad4fa999797dd12e