### PR TITLE
Add CSV mapping export

### DIFF
--- a/app.py
+++ b/app.py
@@ -547,6 +547,32 @@ def download_file():
     )
 
 
+@app.route('/download_mapping')
+def download_mapping():
+    """Download a CSV of the original to matched name mapping."""
+    confirmed = session.get('confirmed_mappings', {})
+    file_name = session.get('file_name', 'mapping.csv')
+
+    mapping_df = pd.DataFrame(
+        [(orig, match) for orig, match in confirmed.items()],
+        columns=['original_name', 'matched_name']
+    )
+
+    buffer = io.StringIO()
+    mapping_df.to_csv(buffer, index=False)
+    buffer.seek(0)
+
+    base = os.path.splitext(secure_filename(file_name))[0]
+    download_name = f"{base}_mapping.csv"
+
+    return send_file(
+        io.BytesIO(buffer.getvalue().encode('utf-8')),
+        mimetype='text/csv',
+        as_attachment=True,
+        download_name=download_name
+    )
+
+
 
 @app.errorhandler(RequestEntityTooLarge)
 def handle_large_file(error):

--- a/html/edit_table.html
+++ b/html/edit_table.html
@@ -65,6 +65,7 @@
       <a href="/preview_data" class="button">← Back to Upload</a>
       <a href="/reset_matches" class="button">Reset All</a>
       <a href="/reset_matches?page={{ current_page }}&per_page={{ per_page }}&scope=page" class="button">Reset This Page</a>
+      <a href="/download_mapping" class="button" onclick="saveMapping(event)">Save Mapping</a>
       <a href="/download_file" class="button" onclick="saveEditsBeforeDownload(event)">Submit & Download File</a>
     </div>
   </form>
@@ -159,6 +160,25 @@
         window.location.href = '/download_file';
       }).catch(err => {
         alert('Failed to prepare download. Please try again.');
+      console.error(err);
+      });
+  }
+
+  function saveMapping(event) {
+    event.preventDefault();
+    const form = document.getElementById('countryForm');
+    const actionInput = document.getElementById('action-hidden');
+    actionInput.value = 'finish';
+    const formData = new FormData(form);
+
+    fetch('/review_matches', {
+      method: 'POST',
+      body: formData,
+    }).then(response => response.text())
+      .then(() => {
+        window.location.href = '/download_mapping';
+      }).catch(err => {
+        alert('Failed to prepare mapping. Please try again.');
         console.error(err);
       });
   }


### PR DESCRIPTION
## Summary
- add a new `/download_mapping` route to export the edited name mappings
- update `edit_table.html` to provide a **Save Mapping** button and JS helper

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6883de35f9e4832781ac2600495f8768